### PR TITLE
fixes flex-wrap bug with box-sizing: border-box

### DIFF
--- a/assets/stylesheets/common/events.scss
+++ b/assets/stylesheets/common/events.scss
@@ -248,11 +248,13 @@
   margin-top: 15px;
   border-bottom: 1px solid $primary-medium;
   border-left: 1px solid $primary-medium;
+  box-sizing: border-box;
 
   .day, .weekday {
-    width: calc(100%/7 - 1px);
+    width: calc(100%/7);
     border-top: 1px solid $primary-medium;
     border-right: 1px solid $primary-medium;
+    box-sizing: border-box;
   }
 
   .weekday {
@@ -266,15 +268,11 @@
 
   .day {
     height: 105px;
+    background-color: $secondary;
     transition: all 0.2s;
     position: relative;
 
-    .container {
-      background-color: $secondary;
-      height: inherit;
-    }
-
-    &.today .container {
+    &.today {
       background-color: $highlight-low;
     }
 


### PR DESCRIPTION
Hi @angusmcleod 
Your Plugin is really great. Thanks a million!
One user of my site reported a bug, that one week in calendar view has only 6 days (on Windows using Firefox - don't know which version). The last day of the week jumps to the next row. Changing the box-model to border-box fixes this.
![eeaef4f7f433118286e5915906568d06e3041b5e](https://user-images.githubusercontent.com/16748711/36442154-174145b0-1675-11e8-8920-f95b648e4706.png)
Cheers, Crispin