### PR TITLE
Fix end dates on add to calendar links

### DIFF
--- a/assets/javascripts/discourse/lib/date-utilities.js.es6
+++ b/assets/javascripts/discourse/lib/date-utilities.js.es6
@@ -88,7 +88,7 @@ let uriDateTimes = function(event) {
   let format = event.all_day ? "YYYYMMDD" : "YYYYMMDDTHHmmss";
   let rawStart = event.start;
   let start = moment(rawStart).local().format(format);
-  let rawEnd = moment(event.end).add(1, 'days') || moment(event.start).add(1, 'days');
+  let rawEnd = event.end ? moment(event.end) : moment(event.start).add(1, 'days');
   let end = moment(rawEnd).local().format(format);
   return { start, end };
 };


### PR DESCRIPTION
Currently, on events where the end time has been omitted, the current time is erroneously added as the end time. If an end time has been provided, a day is added, resulting in a calendar event with a different end time than is shown in the Discourse instance. This change fixes both issues.