### PR TITLE
set event url to topic url

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -496,7 +496,7 @@ after_initialize do
             end
             e.summary = t.title
             e.description = t.excerpt
-            e.url = calendar_url
+            e.url = t.url
           end
         end
       end


### PR DESCRIPTION
Setting the event url to the topic url allows users to track the discussion of the event.

Issue: https://github.com/angusmcleod/discourse-events/issues/45