### PR TITLE
DEV: resolve Rails/ReversibleMigrationMethodDefinition errors

### DIFF
--- a/db/migrate/20191016154136_rsvp_migration.rb
+++ b/db/migrate/20191016154136_rsvp_migration.rb
@@ -17,4 +17,8 @@ class RsvpMigration < ActiveRecord::Migration[5.2]
       custom_field.save
     end
   end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
 end


### PR DESCRIPTION
We are adding the Rails/ReversibleMigrationMethodDefinition cop to rubocop-discourse, this change resolves existing errors under this rule.