### PR TITLE
DEV: Update plugin annotations

### DIFF
--- a/app/models/discourse_events/connection.rb
+++ b/app/models/discourse_events/connection.rb
@@ -58,7 +58,7 @@ end
 #  user_id     :bigint
 #  source_id   :bigint           not null
 #  category_id :bigint
-#  client      :string           default("events")
+#  client      :string           default("discourse_events")
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
 #

--- a/app/models/discourse_events/event.rb
+++ b/app/models/discourse_events/event.rb
@@ -37,7 +37,6 @@ end
 # Table name: discourse_events_events
 #
 #  id            :bigint           not null, primary key
-#  uid           :string           not null
 #  start_time    :datetime         not null
 #  end_time      :datetime
 #  name          :string
@@ -47,16 +46,8 @@ end
 #  url           :string
 #  series_id     :string
 #  occurrence_id :string
-#  source_id     :bigint
-#  provider_id   :bigint
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
-#
-# Indexes
-#
-#  discourse_events_event_id_index               (uid,provider_id) UNIQUE
-#  index_discourse_events_events_on_provider_id  (provider_id)
-#  index_discourse_events_events_on_source_id    (source_id)
 #
 # Foreign Keys
 #

--- a/app/models/discourse_events/event_connection.rb
+++ b/app/models/discourse_events/event_connection.rb
@@ -25,12 +25,10 @@ end
 #  event_id      :bigint           not null
 #  connection_id :bigint           not null
 #  topic_id      :bigint
-#  post_id       :bigint
 #  series_id     :string
 #  client        :string
 #  created_at    :datetime         not null
 #  updated_at    :datetime         not null
-#  external_id   :string
 #
 # Indexes
 #

--- a/app/models/discourse_events/event_source.rb
+++ b/app/models/discourse_events/event_source.rb
@@ -11,21 +11,22 @@ end
 
 # == Schema Information
 #
-# Table name: discourse_events_event_connections
+# Table name: discourse_events_event_sources
 #
-#  id            :bigint           not null, primary key
-#  event_id      :bigint           not null
-#  source_id     :bigint           not null
-#  uid           :string
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
+#  id         :bigint           not null, primary key
+#  uid        :string           not null
+#  source_id  :bigint
+#  event_id   :bigint
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
 #
 # Indexes
 #
-#  discourse_events_event_connections_event  (event_id)
+#  index_discourse_events_event_sources_on_event_id   (event_id)
+#  index_discourse_events_event_sources_on_source_id  (source_id)
 #
 # Foreign Keys
 #
-#  fk_rails_...  (connection_id => discourse_events_connections.id)
 #  fk_rails_...  (event_id => discourse_events_events.id)
+#  fk_rails_...  (source_id => discourse_events_sources.id)
 #

--- a/app/models/discourse_events/source.rb
+++ b/app/models/discourse_events/source.rb
@@ -172,7 +172,7 @@ end
 #  taxonomy       :string
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
-#  sync_type      :integer
+#  sync_type      :integer          default("import")
 #
 # Indexes
 #


### PR DESCRIPTION
We are adding annotations checks to the `.github` for the plugin CI.

More can be seen at https://github.com/discourse/.github/pull/156


And this[ plugin uses that CI YAML](https://github.com/angusmcleod/discourse-events/blob/71f3e50e6b80cb3116dfe91a366ef994e13cd928/.github/workflows/discourse-plugin.yml#L13), we wanted to be sure and not disturb your workflow
