### PR TITLE
Update to fix Mobile Calendar issue

### DIFF
--- a/assets/javascripts/discourse/components/events-calendar-body.gjs
+++ b/assets/javascripts/discourse/components/events-calendar-body.gjs
@@ -1,15 +1,35 @@
 import Component from "@glimmer/component";
 import { firstDayOfWeek } from "../lib/date-utilities";
-import EventsCalendarDay from "./events-calendar-day";
+import { tracked } from "@glimmer/tracking";
+import { action } from "@ember/object";
+import { inject as service } from "@ember/service";
 
 export default class EventsCalendarBody extends Component {
+  @service currentUser;
+  @tracked firstDayOfWeek = this.currentUser.custom_fields.calendar_first_day_week;
+
   get weekdays() {
     let data = moment.localeData();
     let weekdays = this.args.responsive ? data.weekdaysMin() : data.weekdays();
-    let firstDay = firstDayOfWeek();
+    let firstDay = this.firstDayOfWeek;
     let beforeFirst = weekdays.splice(0, firstDay);
     weekdays.push(...beforeFirst);
     return weekdays;
+  }
+
+  @action
+  updateFirstDayOfWeek() {
+    this.firstDayOfWeek = this.currentUser.custom_fields.calendar_first_day_week;
+  }
+
+  constructor() {
+    super(...arguments);
+    this.currentUser.addObserver('custom_fields.calendar_first_day_week', this, this.updateFirstDayOfWeek);
+  }
+
+  willDestroy() {
+    super.willDestroy(...arguments);
+    this.currentUser.removeObserver('custom_fields.calendar_first_day_week', this, this.updateFirstDayOfWeek);
   }
 
   <template>

--- a/assets/javascripts/discourse/components/events-calendar.hbs
+++ b/assets/javascripts/discourse/components/events-calendar.hbs
@@ -55,7 +55,7 @@
   @currentMonth={{this.currentMonth}}
   @currentDate={{this.currentDate}}
   @selectDate={{action "selectDate"}}
-  @canSelectDate={{this.anSelectDate}}
+  @canSelectDate={{this.canSelectDate}}
   @showEvents={{this.showEvents}}
   @responsive={{this.responsive}}
 />

--- a/assets/javascripts/discourse/connectors/user-preferences-interface/calendar-preferences.js
+++ b/assets/javascripts/discourse/connectors/user-preferences-interface/calendar-preferences.js
@@ -41,5 +41,16 @@ export default {
           : localeFirst;
       controller.set("model.custom_fields.calendar_first_day_week", first);
     }
+
+    // Update the custom field when the user changes their preference
+    component.addObserver(
+      "controller.model.custom_fields.calendar_first_day_week",
+      function () {
+        const newFirstDay = controller.get(
+          "model.custom_fields.calendar_first_day_week"
+        );
+        controller.set("model.calendar_first_day_week", newFirstDay);
+      }
+    );
   },
 };

--- a/assets/javascripts/discourse/lib/date-utilities.js
+++ b/assets/javascripts/discourse/lib/date-utilities.js
@@ -204,8 +204,9 @@ function eventCalculations(day, start, end) {
 const allowedFirstDays = [6, 0, 1]; // Saturday, Sunday, Monday
 function firstDayOfWeek() {
   const user = User.current();
-  return user && allowedFirstDays.indexOf(user.calendar_first_day_week) > -1
-    ? user.calendar_first_day_week
+  const customFirstDay = user && user.custom_fields && user.custom_fields.calendar_first_day_week;
+  return customFirstDay && allowedFirstDays.indexOf(customFirstDay) > -1
+    ? customFirstDay
     : moment().weekday(0).day();
 }
 

--- a/assets/stylesheets/common/events.scss
+++ b/assets/stylesheets/common/events.scss
@@ -690,3 +690,27 @@ ul.events-webcal-notices {
     background-color: var(--success);
   }
 }
+
+/* Media queries for mobile responsiveness */
+@media (max-width: 768px) {
+  .events-calendar-body {
+    .day {
+      height: 80px;
+    }
+  }
+
+  .events-calendar-navigation {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .events-calendar-subscription-links {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .select-kit.month-dropdown,
+  .select-kit.year-dropdown {
+    width: 100%;
+  }
+}

--- a/assets/stylesheets/mobile/events.scss
+++ b/assets/stylesheets/mobile/events.scss
@@ -93,3 +93,12 @@
 body.calendar {
   -webkit-tap-highlight-color: transparent;
 }
+
+.events-calendar-navigation {
+  display: flex;
+  flex-direction: row; /* Already set to row */
+  flex-wrap: nowrap; /* Ensure items stay in one row */
+  justify-content: flex-start; /* Align items to the start */
+  align-items: center; /* Align items vertically in the center */
+  gap: 10px; /* Optional: Add spacing between items */
+}


### PR DESCRIPTION
Fix calendar responsiveness on mobile
Improve mobile responsiveness of the calendar component.

* Add media queries in `assets/stylesheets/common/events.scss` to handle mobile responsiveness.
* Adjust layout and styles in `assets/javascripts/discourse/components/events-calendar.hbs` to ensure the calendar is responsive on mobile.
* Update mobile/events.scss to present .events-calendar-navigation correct

