### PR TITLE
Update Add Event CSS for Mobile

### DIFF
--- a/assets/stylesheets/mobile/events.scss
+++ b/assets/stylesheets/mobile/events.scss
@@ -93,3 +93,45 @@
 body.calendar {
   -webkit-tap-highlight-color: transparent;
 }
+
+/* Add Event Layout */
+.datetime-controls,
+.date-time-set {
+  display: flex;
+  flex-direction: column; /* Stack sections vertically */
+}
+
+/* Date and Time Areas */
+.date-area,
+.time-area {
+  display: flex;
+  flex-direction: column; /* Stack label and input vertically */
+  width: 100%; /* Ensure full width */
+  box-sizing: border-box; /* Include padding in width/height */
+}
+
+.date-area label,
+.time-area label {
+  font-weight: bold; /* Emphasize labels */
+  margin-bottom: 4px; /* Add space below labels */
+}
+
+.date-area input,
+.time-area details {
+  padding: 8px; /* Add internal spacing for inputs and dropdowns */
+}
+
+/* Event Controls */
+.event-controls {
+  display: flex;
+  flex-wrap: wrap; /* Enable wrapping for controls */
+}
+
+.event-controls .control {
+  flex: 1 1 auto; /* Flexible controls, side-by-side */
+  min-width: 150px; /* Minimum width for controls */
+}
+
+.event-controls .control.full-width {
+  flex: 1 1 100%; /* Full-width control spans entire row */
+}

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # name: discourse-events
 # about: Allows you to manage events in Discourse
-# version: 0.9.3
+# version: 0.9.4
 # authors: Angus McLeod
 # contact_emails: angus@angus.blog
 # url: https://github.com/angusmcleod/discourse-events


### PR DESCRIPTION
Update Add Event CSS to make it useable on phones 

Before
![Before](https://github.com/user-attachments/assets/63f1730a-24d7-4765-af51-69e4b483cc12)

After
![After](https://github.com/user-attachments/assets/06de28de-f699-45cd-9b5d-4b1f275ea34a)

Sadly don't know EmberJS enough to work out how to remove the divider next the 'End' so it lines up better, or remove the "Date" placeholder text to make the input fields look better  - but hopefully this CSS change is a good start