### PR TITLE
DEV: replace load-more mixin with component

### DIFF
--- a/.discourse-compatibility
+++ b/.discourse-compatibility
@@ -1,1 +1,2 @@
+< 3.5.0.beta3-dev: b4e6760fb531174449a0f2220d096fc75c37dc6a
 3.2.0.beta2: c18cbeeac5a3f7ebf540cd6fc7edef48db889edd

--- a/assets/javascripts/discourse/components/events-event-table.hbs
+++ b/assets/javascripts/discourse/components/events-event-table.hbs
@@ -48,6 +48,7 @@
         @showTopics={{this.showTopics}}
       />
     {{/each}}
+    <LoadMore @action={{action "loadMore"}} />
   </tbody>
 </table>
 <ConditionalLoadingSpinner @condition={{this.loading}} />

--- a/assets/javascripts/discourse/components/events-event-table.js
+++ b/assets/javascripts/discourse/components/events-event-table.js
@@ -1,11 +1,9 @@
 import Component from "@ember/component";
-import LoadMore from "discourse/mixins/load-more";
 import discourseComputed from "discourse-common/utils/decorators";
 import Event from "../models/event";
 
-export default Component.extend(LoadMore, {
+export default Component.extend({
   classNames: ["events-event-table"],
-  eyelineSelector: ".events-event-row",
   loadingComplete: false,
 
   @discourseComputed("filter")

--- a/assets/javascripts/discourse/components/events-log-table.hbs
+++ b/assets/javascripts/discourse/components/events-log-table.hbs
@@ -1,7 +1,4 @@
-<LoadMore
-  @selector=".directory-table .directory-table__cell"
-  @action={{action "loadMore"}}
->
+<LoadMore @action={{action "loadMore"}}>
   <ResponsiveTable @className="events-log-table">
     <:header>
       <TableHeaderToggle

--- a/assets/javascripts/discourse/templates/admin-plugins-events-event.hbs
+++ b/assets/javascripts/discourse/templates/admin-plugins-events-event.hbs
@@ -66,10 +66,7 @@
 
 <div class="admin-events-container">
   {{#if this.hasEvents}}
-    <LoadMore
-      @selector=".directory-table .directory-table__cell"
-      @action={{action "loadMore"}}
-    >
+    <LoadMore @action={{action "loadMore"}}>
       <ResponsiveTable @className="events-event-table">
         <:header>
           <TableHeaderToggle

--- a/assets/javascripts/discourse/templates/admin-plugins-events-log.hbs
+++ b/assets/javascripts/discourse/templates/admin-plugins-events-log.hbs
@@ -2,10 +2,7 @@
 
 <div class="admin-events-container">
   {{#if this.hasLogs}}
-    <LoadMore
-      @selector=".directory-table .directory-table__cell"
-      @action={{action "loadMore"}}
-    >
+    <LoadMore @action={{action "loadMore"}}>
       <ResponsiveTable @className="events-log-table">
         <:header>
           <TableHeaderToggle


### PR DESCRIPTION
Follow up from https://github.com/discourse/discourse/pull/32285. 

The LoadMore component was recently refactored to use an intersection observer based approach (set on a sentinel element) instead of observing scroll events, as well as to handle both scenarios where we yield template content into the component or just use the component by itself. 

This allows us to explicitly set a LoadMore component in the EventsEventTable template, and also to remove the need to pass in selector-related values to LoadMore.

The load-more mixin will be removed shortly, so this PR also handles removal of that dependency.