### PR TITLE
Fix calendar view leaking to non-calendar categories during SPA navigation - Update discourse-events.js

### DIFF
--- a/assets/javascripts/discourse/initializers/discourse-events.js
+++ b/assets/javascripts/discourse/initializers/discourse-events.js
@@ -129,14 +129,21 @@ export default {
         pluginId: "discourse-events",
 
         afterModel(model) {
+          const calendarEnabled =
+            siteSettings.events_calendar_enabled ||
+            (model.category && model.category.events_calendar_enabled);
+
           if (
             model.filterType === "calendar" &&
+            calendarEnabled &&
             this.templateName === "discovery/list"
           ) {
             this.templateName = "discovery/calendar";
+          } else if (this.templateName === "discovery/calendar") {
+            this.templateName = "discovery/list";
           }
         },
-      });
+      });     
 
       api.addNavigationBarItem({
         name: "calendar",


### PR DESCRIPTION
## Problem

The `afterModel` hook on `route:discovery.category` swaps the template to `discovery/calendar` based solely on `model.filterType === "calendar"`, without checking whether the category actually has calendar enabled.

During SPA navigation, `filterType` persists on the Ember controller. Once a user visits any calendar-enabled category, `filterType: "calendar"` leaks to all subsequent category visits on the base route (`/c/slug/id`), causing the calendar view to appear on categories where it should not.

This only affects the base route  `/c/slug/id/l/latest` and `/c/slug/id/l/all` use different Ember routes and are unaffected.

Related Meta reports:
- https://meta.discourse.org/t/cant-disable-the-category-calendar-once-it-is-enabled/342112
- https://meta.discourse.org/t/with-events-enabled-calendar-disappears-from-view-when-changing-category-view/270836

## Fix

1. Add a guard checking `siteSettings.events_calendar_enabled` or `category.events_calendar_enabled` before swapping the template (consistent with how `addNavigationBarItem` already checks it at line 144).
2. Add an `else` branch to reset `templateName` back to `discovery/list` when the calendar should not be shown — this prevents the leaked `filterType` from persisting the calendar template across navigations.

## Testing

1. Enable `events_calendar_enabled` on one category (e.g. "Events")
2. Visit the Events category → calendar view should appear
3. Navigate to a non-calendar category → **no calendar** (was broken before)
4. Navigate back to Events → calendar should still work
