### PR TITLE
FIX: preserve calendar view when navigating months

### DIFF
--- a/assets/javascripts/discourse/components/events-calendar.js
+++ b/assets/javascripts/discourse/components/events-calendar.js
@@ -148,37 +148,42 @@ export default Component.extend({
     }
     this.set("loading", true);
 
-    return router
-      .transitionTo({
-        queryParams: { start, end },
-      })
-      .then(() => {
-        const category = this.get("category");
-        let filter = "";
+    const category = this.get("category");
+    const queryParams = { queryParams: { start, end } };
+    const transitionPromise = category
+      ? router.transitionTo(
+          "discovery.calendarCategory",
+          `${Category.slugFor(category)}/${category.id}`,
+          queryParams
+        )
+      : router.transitionTo("discovery.calendar", queryParams);
 
-        if (category) {
-          filter += `c/${Category.slugFor(category)}/l/`;
-        }
-        filter += "calendar";
+    return transitionPromise.then(() => {
+      let filter = "";
 
-        this.store
-          .findFiltered("topicList", {
-            filter,
-            params: { start, end },
-          })
-          .then((list) => {
-            if (this._state === "destroying") {
-              return;
-            }
+      if (category) {
+        filter += `c/${Category.slugFor(category)}/l/`;
+      }
+      filter += "calendar";
 
-            this.setProperties({
-              topics: list.topics,
-              currentMonth: month,
-              currentYear: year,
-              loading: false,
-            });
+      this.store
+        .findFiltered("topicList", {
+          filter,
+          params: { start, end },
+        })
+        .then((list) => {
+          if (this._state === "destroying") {
+            return;
+          }
+
+          this.setProperties({
+            topics: list.topics,
+            currentMonth: month,
+            currentYear: year,
+            loading: false,
           });
-      });
+        });
+    });
   },
 
   @observes("month", "year")


### PR DESCRIPTION
## Problem

After the category route fix in #166, navigating between months in the
calendar view incorrectly switches the view to the list template, even
when the user stays within a calendar-enabled category.

**Steps to reproduce:**
1. Open a calendar-enabled category (e.g. `/c/events/20`)
2. Verify calendar view is rendered
3. Click the "next month" or "previous month" arrow
4. URL changes to `/c/events/20?start=...&end=...` (note the missing `/l/calendar`)
5. View flips to list - expected: calendar for the new month

The same issue affects the global calendar route (`/calendar`).

## Root cause

`transitionToMonth()` in `events-calendar.js` called:

```js
router.transitionTo({ queryParams: { start, end } });
```

Without an explicit route name, Ember resolved the transition to the
category's base route (`discovery.category`) instead of the calendar
filter route - the `/l/calendar` segment was dropped from the URL.

The `afterModel` hook in `route:discovery.category` (modified in #166
to prevent calendar template leaking into non-calendar categories) then
sees `model.filterType !== "calendar"` and executes:

```js
} else if (this.templateName === "discovery/calendar") {
  this.templateName = "discovery/list";
}
```

resetting the template to list. Topics for the new month are loaded
correctly, but rendered in the wrong view.

This bug existed before #166 but was masked by the earlier template
leak - #166 correctly fixed that leak, which surfaced this pre-existing
issue in `transitionToMonth`.

## Fix

Transition explicitly to the correct calendar route so the filter is
preserved in the URL:

- `discovery.calendarCategory` with `category_slug_path_with_id` as
  positional parameter when a category context exists
- `discovery.calendar` for the global calendar route (no dynamic segments)

The routes `xxxCategory` are dynamically generated by Discourse core's
[app-route-map.js](https://github.com/discourse/discourse/blob/main/frontend/discourse/app/routes/app-route-map.js)
from `Site.currentProp("filters")`, with a single `*category_slug_path_with_id`
glob segment in the format `<slug>/<id>`. This matches how Discourse core
itself transitions, e.g. in `build-category-route.js`:

```js
this.router.replaceWith(
  "discovery.categoryNone",
  params.category_slug_path_with_id
);
```

The `const category = this.get("category")` lookup is hoisted to the top
of the function since it is now needed both for route selection and in
the existing `.then()` callback (minor deduplication).

## Testing

Tested manually on Discourse Version: 2026.4.0-latest ( [480a052a10 ](https://github.com/discourse/discourse/commits/480a052a1016527b277e7071c1584c9e7f758d0b))

- ✅ Category calendar: next month stays in calendar view
- ✅ Category calendar: previous month stays in calendar view
- ✅ Category calendar: "Today" button returns to current month in calendar view
- ✅ Global calendar (`/calendar`): month navigation stays in calendar view
- ✅ Topics for the new month are loaded correctly
- ✅ Navigating from calendar category to non-calendar category still
     correctly shows list view (regression check for #166)

## Related

- Relates to #166